### PR TITLE
Updated with EnumFlag 

### DIFF
--- a/examples/vhost-example.rs
+++ b/examples/vhost-example.rs
@@ -62,12 +62,12 @@ fn main() {
     println!("{:?}", create_host_interface);
 
     // Step 4: Set Host Interface State up
-    /* let set_interface_link_up: SwInterfaceSetFlagsReply = send_recv_msg(
+    let set_interface_link_up: SwInterfaceSetFlagsReply = send_recv_msg(
         &SwInterfaceSetFlags::get_message_name_and_crc(),
-        &SwInterfaceSetFlags::builder().client_index(t.get_client_index()).context(0).sw_if_index(1).flags(IfStatusFlags::IF_STATUS_API_FLAG_ADMIN_UP).build().unwrap(),
+        &SwInterfaceSetFlags::builder().client_index(t.get_client_index()).context(0).sw_if_index(1).flags(vec![IfStatusFlags::IF_STATUS_API_FLAG_ADMIN_UP, IfStatusFlags::IF_STATUS_API_FLAG_LINK_UP].try_into().unwrap()).build().unwrap(),
         &mut *t,
         &SwInterfaceSetFlagsReply::get_message_name_and_crc());
-    */
+    
     println!("{:?}", create_host_interface);
 
     // Step 5: Assign IP Address to Host Interface
@@ -122,8 +122,7 @@ fn main() {
     // println!("Show VhostInterfaceDetails \n {:?}", vhostDetails);
 
     // Verify creation of Interface
-    /* 
-    FIXME: Need to implement Deserialize for FixedSizeArray to make this work
+    // FIXME: Need to implement Deserialize for FixedSizeArray to make this work
     let swinterfacedetails: Vec<SwInterfaceDetails> = send_bulk_msg(
         &SwInterfaceDump::get_message_name_and_crc(),
         &SwInterfaceDump::builder()
@@ -143,7 +142,7 @@ fn main() {
         acc.push_str(&format!("{:?} \n", &x.sw_if_index));
         acc
     });
-    println!("{}", interfaceids);*/ 
+    println!("{}", interfaceids);
     // If non empty, Test out by pinging from host
 
     t.disconnect();

--- a/src/bin/api-gen/code_gen.rs
+++ b/src/bin/api-gen/code_gen.rs
@@ -82,7 +82,7 @@ pub fn create_cargo_toml(packageName: &str) {
     code.push_str(
         "vpp-macros = {git=\"https://github.com/felixfaisal/vpp-macros\", branch=\"main\"} \n",
     );
-    code.push_str("enumset = {version=\"1.0.7\", features=[\"serde\"]} \n");
+    code.push_str("enumset = {git=\"https://github.com/ayourtch/enumset\", branch=\"master\", features=[\"serde\", \"enumflags\"]} \n");
 
     let mut file = File::create(format!(".././{}/Cargo.toml", packageName)).unwrap();
     file.write_all(code.as_bytes()).unwrap();

--- a/src/bin/api-gen/enums.rs
+++ b/src/bin/api-gen/enums.rs
@@ -150,7 +150,7 @@ impl VppJsApiEnum {
     }
     pub fn generate_as_enumflag_trait(&self) -> String{
         let mut code = String::new();
-        code.push_str(&format!("impl AsEnumFlag for {}\n",camelize_ident(&self.name)));
+        code.push_str(&format!("impl AsEnumFlag for {} {{\n",camelize_ident(&self.name)));
         code.push_str("\t fn as_u32(data: &Self) -> u32{\n");
         code.push_str("\t\t *data as u32\n");
         code.push_str("\t }\n");
@@ -182,7 +182,7 @@ impl VppJsApiEnum {
             println!("{:#?}", self);
             // This tells if the enum is a flag or not
             code.push_str(&format!(
-                "#[derive(Debug,Serialize, Deserialize)] \n"
+                "#[derive(Debug,Serialize, Deserialize, Clone, Copy)] \n"
             ));
             /* match &self.info.enumtype {
                 Some(len) => code.push_str(&format!("#[repr({})]\n", &len)),

--- a/src/bin/api-gen/enums.rs
+++ b/src/bin/api-gen/enums.rs
@@ -108,35 +108,96 @@ impl<'de> Deserialize<'de> for VppJsApiEnum {
         deserializer.deserialize_seq(VppJsApiEnumVisitor)
     }
 }
+pub fn isPowerOfTwo(n: &mut i64) -> bool 
+{
+    if *n == 0{
+        return false;
+    }
+    while *n != 1
+    {
+        if *n%2 != 0{
+            return false;
+        }    
+        *n = *n/2;
+    }
+    return true;
+}
 impl VppJsApiEnum {
     pub fn if_flag(&self) -> bool {
+        if self.name.contains("flag"){
+            return true;
+        }
         let mut prev: i64 = self.values[0].value;
         for x in 1..self.values.len() {
             if self.values[x].value == 0 {
                 continue;
+            }
+            if !isPowerOfTwo(&mut self.values[x].value.clone()){
+                return false;
             }
             let next = prev + 1;
             if self.values[x].value == next {
                 prev = next;
                 continue;
             } else {
+                if isPowerOfTwo(&mut self.values[x+1].value.clone()){
+                    return true;
+                }
                 return false;
             }
         }
-        true
+        false
+    }
+    pub fn generate_as_enumflag_trait(&self) -> String{
+        let mut code = String::new();
+        code.push_str(&format!("impl AsEnumFlag for {}\n",camelize_ident(&self.name)));
+        code.push_str("\t fn as_u32(data: &Self) -> u32{\n");
+        code.push_str("\t\t *data as u32\n");
+        code.push_str("\t }\n");
+        code.push_str("\t fn from_u32(data: u32) -> Self{\n");
+        code.push_str("\t\t match data{\n");
+        for x in 0..self.values.len() {
+            code.push_str(&format!(
+                "\t\t\t {} => {}::{}, \n",
+                self.values[x].value,
+                camelize_ident(&self.name),
+                get_ident(&self.values[x].name)
+            ));
+        }
+        code.push_str("\t\t\t_ => panic!(\"Invalid Enum Descriminant\")\n");
+        code.push_str("\t\t }\n");
+        code.push_str("\t }\n");
+        code.push_str("\t fn size_of_enum_flag() -> u32{\n");
+        match &self.info.enumtype {
+            Some(len) => code.push_str(&format!("\t\t {} as u32\n", len.trim_start_matches("u"))),
+            _ => code.push_str(&format!("\t\t 32 as u32\n")),
+        }
+        code.push_str("\t}\n");
+        code.push_str("}\n");
+        code
     }
     pub fn generate_code(&self) -> String {
         let mut code = String::new();
-        code.push_str(&format!(
-            "#[derive(Debug, Clone, Serialize_repr, Deserialize_repr)] \n"
-        ));
-        if !self.if_flag() {
-            // println!("{:#?}", self);
+        if self.if_flag() {
+            println!("{:#?}", self);
             // This tells if the enum is a flag or not
+            code.push_str(&format!(
+                "#[derive(Debug,Serialize, Deserialize)] \n"
+            ));
+            /* match &self.info.enumtype {
+                Some(len) => code.push_str(&format!("#[repr({})]\n", &len)),
+                _ => code.push_str(&format!("#[repr({})]\n")),
+            }*/
         }
-        match &self.info.enumtype {
-            Some(len) => code.push_str(&format!("#[repr({})]\n", &len)),
-            _ => code.push_str(&format!("#[repr(u32)]\n")),
+        else{ 
+             // This tells if the enum is a flag or not
+             code.push_str(&format!(
+                "#[derive(Debug, Clone, Serialize_repr, Deserialize_repr)] \n"
+            ));
+            match &self.info.enumtype {
+                Some(len) => code.push_str(&format!("#[repr({})]\n", &len)),
+                _ => code.push_str(&format!("#[repr(u32)]\n")),
+            }
         }
         code.push_str(&format!("pub enum {} {{ \n", camelize_ident(&self.name)));
         for x in 0..self.values.len() {
@@ -149,6 +210,9 @@ impl VppJsApiEnum {
         // code.push_str("\t #[serde(other)] \n\t Invalid \n");
         code.push_str("} \n");
         code.push_str(&self.impl_default());
+        if self.if_flag(){
+            code.push_str(&self.generate_as_enumflag_trait());
+        }
         code
     }
     pub fn impl_default(&self) -> String {

--- a/src/bin/api-gen/file_schema.rs
+++ b/src/bin/api-gen/file_schema.rs
@@ -109,6 +109,7 @@ impl VppJsApiFile {
         preamble.push_str("use vpp_api_transport::*;\n");
         preamble.push_str("use serde_repr::{Serialize_repr, Deserialize_repr};\n");
         preamble.push_str("use typenum;\n");
+        preamble.push_str("use enumset::EnumSetType;\n");
         let mut import_table: Vec<(String, Vec<String>)> = vec![];
         let typstructs = VppJsApiType::iter_and_generate_code(
             &self.types,

--- a/src/bin/api-gen/message.rs
+++ b/src/bin/api-gen/message.rs
@@ -120,7 +120,11 @@ impl VppJsApiMessage {
                     },
                     _ => code.push_str(&format!("\tpub {} :, \n", get_ident(&self.fields[x].name))),
                 }
-            } else {
+            } 
+            else if self.fields[x].ctype.contains("flag"){
+                code.push_str(&format!("\t pub {} : EnumFlag<{}>, \n",get_ident(&self.fields[x].name),get_type(&self.fields[x].ctype) ));
+            }
+            else {
                 code.push_str(&format!("\tpub {} : ", get_ident(&self.fields[x].name)));
                 match &self.fields[x].maybe_size {
                     Some(cont) => match cont {

--- a/src/bin/api-gen/types.rs
+++ b/src/bin/api-gen/types.rs
@@ -94,7 +94,11 @@ impl VppJsApiType {
                     },
                     _ => code.push_str(&format!("{}, \n", get_ident(&self.fields[x].name))),
                 }
-            } else {
+            } 
+            else if self.fields[x].ctype.contains("flag"){
+                code.push_str(&format!("EnumFlag<{}>, \n",get_type(&self.fields[x].ctype) ));
+            }
+            else {
                 match &self.fields[x].maybe_size {
                     Some(cont) => match cont {
                         VppJsApiFieldSize::Fixed(len) => code.push_str(&format!(


### PR DESCRIPTION
This PR addresses use of EnumFlag as updated in the latest PR for vpp-api-encoding 
A test for bulk messages, with Enum flag: 
``` 
SwInterfaceDetails {
        context: 0,
        sw_if_index: 1,
        sup_sw_if_index: 1,
        l2_address: [
            2,
            254,
            163,
            81,
            215,
            102,
        ],
        flags: EnumFlag(
            [
                IF_STATUS_API_FLAG_LINK_UP,
                IF_STATUS_API_FLAG_ADMIN_UP,
            ],
        ),
        typ: IF_API_TYPE_HARDWARE,
        link_duplex: LINK_DUPLEX_API_UNKNOWN,
        link_speed: 0,
        link_mtu: 9216,
        mtu: FixedSizeArray[4]: [[9000, 0, 0, 0]],
        sub_id: 0,
        sub_number_of_tags: 0,
        sub_outer_vlan_id: 0,
        sub_inner_vlan_id: 0,
        sub_if_flags: EnumFlag(
            [],
        ),
        vtr_op: 0,
        vtr_push_dot1q: 0,
        vtr_tag1: 0,
        vtr_tag2: 0,
        outer_tag: 0,
        b_dmac: [
            0,
            0,
            0,
            0,
            0,
            0,
        ],
        b_smac: [
            0,
            0,
            0,
            0,
            0,
            0,
        ],
        b_vlanid: 0,
        i_sid: 0,
        interface_name: FixedSizeString[64]: "host-vpp1out",
        interface_dev_type: FixedSizeString[64]: "af-packet",
        tag: FixedSizeString[64]: "",
    },
 ``` 
 Showing deserialization of **EnumFlag** successful along with that of **FixedSizeArray**
 To get  this output, Follow the same procedure to run the example after creating package 