### PR TITLE
Created support for generating single file bindings

### DIFF
--- a/src/bin/api-gen/code_gen.rs
+++ b/src/bin/api-gen/code_gen.rs
@@ -24,6 +24,20 @@ use crate::parser_helper::{camelize_ident, get_ident, get_type};
 use crate::types::VppJsApiType;
 use crate::types::{VppJsApiFieldSize, VppJsApiMessageFieldDef};
 
+pub fn gen_code_file(code: &VppJsApiFile, name: &str, api_definition: &mut Vec<(String, String)>){
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r"[a-z_0-9]*.api.json").unwrap();
+    }
+    let fileName = RE
+        .find(&name)
+        .unwrap()
+        .as_str()
+        .trim_end_matches(".api.json");
+        let mut file = File::create(format!(".././{}.rs",fileName)).unwrap();
+    file.write_all(code.generate_code(name, api_definition).as_bytes())
+        .unwrap();
+    println!("Generated {}.rs", fileName.trim_start_matches("/"));
+}
 pub fn gen_code(
     code: &VppJsApiFile,
     name: &str,

--- a/src/bin/api-gen/enums.rs
+++ b/src/bin/api-gen/enums.rs
@@ -179,7 +179,6 @@ impl VppJsApiEnum {
     pub fn generate_code(&self) -> String {
         let mut code = String::new();
         if self.if_flag() {
-            println!("{:#?}", self);
             // This tells if the enum is a flag or not
             code.push_str(&format!(
                 "#[derive(Debug,Serialize, Deserialize, Clone, Copy)] \n"

--- a/src/bin/api-gen/main.rs
+++ b/src/bin/api-gen/main.rs
@@ -23,7 +23,7 @@ mod message;
 mod parser_helper;
 mod services;
 mod types;
-use crate::code_gen::{create_cargo_toml, gen_code, generate_lib_file, copy_file_with_fixup};
+use crate::code_gen::{create_cargo_toml, gen_code, generate_lib_file, copy_file_with_fixup, gen_code_file};
 use crate::file_schema::VppJsApiFile;
 use crate::message::*;
 use crate::parser_helper::*;
@@ -47,8 +47,9 @@ pub enum OptParseType {
 }
 
 /// Ingest the VPP API JSON definition file and output the Rust code
-#[clap(version = "1.0", author = "Andrew Yourtchenko <ayourtch@gmail.com>")]
 #[derive(Clap, Debug, Clone, Serialize, Deserialize)]
+#[clap(version = "1.0", author = "Andrew Yourtchenko <ayourtch@gmail.com>")]
+
 pub struct Opts {
     /// Input file name
     #[clap(short, long)]
@@ -167,7 +168,9 @@ fn main() {
                 let data = serde_json::to_string_pretty(&desc).unwrap();
                 // println!("{}", &data);
                 let mut api_definition: Vec<(String, String)> = vec![];
-                gen_code(&desc, "generated2.", &mut api_definition, "test");
+                if opts.generate_code{
+                    gen_code_file(&desc, &opts.in_file, &mut api_definition);
+                }
             }
             OptParseType::ApiType => {
                 let desc: VppJsApiType = serde_json::from_str(&data).unwrap();

--- a/src/bin/api-gen/message.rs
+++ b/src/bin/api-gen/message.rs
@@ -136,7 +136,6 @@ impl VppJsApiMessage {
                         VppJsApiFieldSize::Variable(t) => {
                             code.push_str(&format!("VariableSizeArray<{}>, \n", get_type(&self.fields[x].ctype)))
                         }
-                        //_ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
                     },
                     _ => code.push_str(&format!("{}, \n", get_type(&self.fields[x].ctype))),
                     /*code.push_str(&format!(

--- a/src/bin/api-gen/message.rs
+++ b/src/bin/api-gen/message.rs
@@ -136,7 +136,7 @@ impl VppJsApiMessage {
                         VppJsApiFieldSize::Variable(t) => {
                             code.push_str(&format!("VariableSizeArray<{}>, \n", get_type(&self.fields[x].ctype)))
                         }
-                        _ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
+                        //_ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
                     },
                     _ => code.push_str(&format!("{}, \n", get_type(&self.fields[x].ctype))),
                     /*code.push_str(&format!(

--- a/src/bin/api-gen/types.rs
+++ b/src/bin/api-gen/types.rs
@@ -109,7 +109,6 @@ impl VppJsApiType {
                         VppJsApiFieldSize::Variable(t) => {
                             code.push_str(&format!("VariableSizeArray<{}>, \n", get_type(&self.fields[x].ctype)))
                         }
-                        //_ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
                     },
                     _ => code.push_str(&format!("{}, \n", get_type(&self.fields[x].ctype))),
                 }

--- a/src/bin/api-gen/types.rs
+++ b/src/bin/api-gen/types.rs
@@ -109,7 +109,7 @@ impl VppJsApiType {
                         VppJsApiFieldSize::Variable(t) => {
                             code.push_str(&format!("VariableSizeArray<{}>, \n", get_type(&self.fields[x].ctype)))
                         }
-                        _ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
+                        //_ => code.push_str(&format!("{},\n", get_type(&self.fields[x].ctype))),
                     },
                     _ => code.push_str(&format!("{}, \n", get_type(&self.fields[x].ctype))),
                 }


### PR DESCRIPTION
This PR will add the following to the existing codebase, 
Allowing users to create rust file for a single *api.json, This will create a single Rust file. It could be used mainly for understanding 1-1 how code is generated from api.json files. 

To generate single file 
```
cargo run --release -- --in-file <fileName> --parse-type File --generate-code
```
To test it out, you can use **acl.api.json** 

```
cargo run --release -- --in-file acl.api.json --parse-type File --generate-code
```
**Output** 
```bash
cargo run --release -- --in-file acl.api.json --parse-type File --generate-code
    Finished release [optimized] target(s) in 0.02s
     Running `target/release/api-gen --in-file acl.api.json --parse-type File --generate-code`
File: acl.api.json version: 0xa832e616 services: 19 types: 10 messages: 38 aliases: 7 imports: 4 enums: 12 unions: 1
Generated acl.rs
```
