### PR TITLE
support - in package names, allow re-generating over existing files.

### DIFF
--- a/src/bin/api-gen/code_gen.rs
+++ b/src/bin/api-gen/code_gen.rs
@@ -11,8 +11,8 @@ use lazy_static::lazy_static;
 use linked_hash_map::LinkedHashMap;
 use regex::Regex;
 use std::fmt::format;
-use std::fs::File;
 use std::fs;
+use std::fs::File;
 use std::io::prelude::*;
 
 use crate::alias::VppJsApiAlias;
@@ -24,7 +24,7 @@ use crate::parser_helper::{camelize_ident, get_ident, get_type};
 use crate::types::VppJsApiType;
 use crate::types::{VppJsApiFieldSize, VppJsApiMessageFieldDef};
 
-pub fn gen_code_file(code: &VppJsApiFile, name: &str, api_definition: &mut Vec<(String, String)>){
+pub fn gen_code_file(code: &VppJsApiFile, name: &str, api_definition: &mut Vec<(String, String)>) {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"[a-z_0-9]*.api.json").unwrap();
     }
@@ -33,7 +33,7 @@ pub fn gen_code_file(code: &VppJsApiFile, name: &str, api_definition: &mut Vec<(
         .unwrap()
         .as_str()
         .trim_end_matches(".api.json");
-        let mut file = File::create(format!(".././{}.rs",fileName)).unwrap();
+    let mut file = File::create(format!(".././{}.rs", fileName)).unwrap();
     file.write_all(code.generate_code(name, api_definition).as_bytes())
         .unwrap();
     println!("Generated {}.rs", fileName.trim_start_matches("/"));
@@ -119,10 +119,12 @@ pub fn generate_lib_file(api_files: &LinkedHashMap<String, VppJsApiFile>, packag
     file.write_all(code.as_bytes()).unwrap();
     // println!("{}", code);
 }
-pub fn copy_file_with_fixup(example_file: &str, packageName: &str, target_name: &str){
-    let data = fs::read_to_string(example_file).unwrap();
-    let packageName = &packageName.replace("-","_");
-    let updated_test = data.replace("vpp_api_gen", packageName); 
-    let mut file = File::create(format!(".././{}/{}", packageName, target_name)).unwrap();
-    file.write_all(updated_test.as_bytes()).unwrap();
+pub fn copy_file_with_fixup(example_file: &str, packageName: &str, target_name: &str) {
+    let data = fs::read_to_string(example_file).expect("Could not read file");
+    let packageCodeName = &packageName.replace("-", "_");
+    let updated_test = data.replace("vpp_api_gen", packageCodeName);
+    let mut file =
+        File::create(format!(".././{}/{}", packageName, target_name)).expect("Error writing file");
+    file.write_all(updated_test.as_bytes())
+        .expect("error writing to file");
 }

--- a/src/bin/api-gen/main.rs
+++ b/src/bin/api-gen/main.rs
@@ -23,7 +23,9 @@ mod message;
 mod parser_helper;
 mod services;
 mod types;
-use crate::code_gen::{create_cargo_toml, gen_code, generate_lib_file, copy_file_with_fixup, gen_code_file};
+use crate::code_gen::{
+    copy_file_with_fixup, create_cargo_toml, gen_code, gen_code_file, generate_lib_file,
+};
 use crate::file_schema::VppJsApiFile;
 use crate::message::*;
 use crate::parser_helper::*;
@@ -168,7 +170,7 @@ fn main() {
                 let data = serde_json::to_string_pretty(&desc).unwrap();
                 // println!("{}", &data);
                 let mut api_definition: Vec<(String, String)> = vec![];
-                if opts.generate_code{
+                if opts.generate_code {
                     gen_code_file(&desc, &opts.in_file, &mut api_definition);
                 }
             }
@@ -238,15 +240,31 @@ fn main() {
                     // println!("{}", opts.package_name);
                     let mut api_definition: Vec<(String, String)> = vec![];
                     println!("Do whatever you need to hear with creating package");
-                    fs::create_dir(&format!(".././{}", opts.package_name)).unwrap();
-                    fs::create_dir(&format!(".././{}/src", opts.package_name)).unwrap();
-                    fs::create_dir(&format!(".././{}/tests", opts.package_name)).unwrap();
-                    fs::create_dir(&format!(".././{}/examples", opts.package_name)).unwrap();
+                    fs::create_dir_all(&format!(".././{}", opts.package_name))
+                        .expect("Error creating package dir");
+                    fs::create_dir_all(&format!(".././{}/src", opts.package_name))
+                        .expect("Error creating package/src dir");
+                    fs::create_dir_all(&format!(".././{}/tests", opts.package_name))
+                        .expect("Error creating package/tests dir");
+                    fs::create_dir_all(&format!(".././{}/examples", opts.package_name))
+                        .expect("Error creating package/examples dir");
                     generate_lib_file(&api_files, &opts.package_name);
                     create_cargo_toml(&opts.package_name);
-                    copy_file_with_fixup("./code-templates/src/reqrecv.rs", &opts.package_name, "src/reqrecv.rs");
-                    copy_file_with_fixup("./code-templates/tests/interface-test.rs", &opts.package_name, "tests/interface_test.rs");
-                    copy_file_with_fixup("./code-templates/examples/progressive-vpp.rs", &opts.package_name, "examples/progressive-vpp.rs");
+                    copy_file_with_fixup(
+                        "./code-templates/src/reqrecv.rs",
+                        &opts.package_name,
+                        "src/reqrecv.rs",
+                    );
+                    copy_file_with_fixup(
+                        "./code-templates/tests/interface-test.rs",
+                        &opts.package_name,
+                        "tests/interface_test.rs",
+                    );
+                    copy_file_with_fixup(
+                        "./code-templates/examples/progressive-vpp.rs",
+                        &opts.package_name,
+                        "examples/progressive-vpp.rs",
+                    );
 
                     let mut import_collection: Vec<ImportsFiles> = vec![];
                     for (name, f) in api_files.clone() {


### PR DESCRIPTION
* allows you to use dashes in the package name
* fixes issue where you couldn't re-generate the package over an existing package