### PR TITLE
add trait definition to abstract the name and crc fetching

### DIFF
--- a/code-templates/src/reqrecv.rs
+++ b/code-templates/src/reqrecv.rs
@@ -6,6 +6,7 @@
     non_camel_case_types,
     unused_imports
 )]
+use crate::VppNamedMessage;
 use bincode::Options;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
@@ -38,6 +39,37 @@ pub struct ControlPingReply {
     pub retval: i32,
     pub client_index: u32,
     pub vpe_pid: u32,
+}
+
+pub fn send_recv_one<
+    'a,
+    T: Serialize + Deserialize<'a> + VppNamedMessage,
+    TR: Serialize + DeserializeOwned + VppNamedMessage,
+>(
+    m: &T,
+    t: &mut dyn VppApiTransport,
+) -> TR {
+    send_recv_msg(
+        &T::get_message_name_and_crc(),
+        m,
+        t,
+        &TR::get_message_name_and_crc(),
+    )
+}
+pub fn send_recv_many<
+    'a,
+    T: Serialize + Deserialize<'a> + VppNamedMessage,
+    TR: Serialize + DeserializeOwned + VppNamedMessage + std::fmt::Debug + Clone,
+>(
+    m: &T,
+    t: &mut dyn VppApiTransport,
+) -> Vec<TR> {
+    send_bulk_msg(
+        &T::get_message_name_and_crc(),
+        m,
+        t,
+        &TR::get_message_name_and_crc(),
+    )
 }
 
 pub fn send_recv_msg<'a, T: Serialize + Deserialize<'a>, TR: Serialize + DeserializeOwned>(

--- a/src/bin/api-gen/code_gen.rs
+++ b/src/bin/api-gen/code_gen.rs
@@ -104,6 +104,7 @@ pub fn create_cargo_toml(packageName: &str) {
 pub fn generate_lib_file(api_files: &LinkedHashMap<String, VppJsApiFile>, packageName: &str) {
     let mut code = String::new();
     code.push_str("pub mod reqrecv; \n");
+    code.push_str("pub trait VppNamedMessage {\n fn get_message_name_and_crc() -> String;\n}\n");
     for (name, f) in api_files.clone() {
         lazy_static! {
             static ref RE: Regex = Regex::new(r"/[a-z_0-9]*.api.json").unwrap();

--- a/src/bin/api-gen/file_schema.rs
+++ b/src/bin/api-gen/file_schema.rs
@@ -106,6 +106,7 @@ impl VppJsApiFile {
         preamble.push_str("use std::convert::TryInto; \n");
         preamble.push_str("use serde::{de::DeserializeOwned, Deserialize, Serialize};\n");
         preamble.push_str("use vpp_api_encoding::typ::*;\n");
+        preamble.push_str("use crate::VppNamedMessage;\n");
         preamble.push_str("use serde_repr::{Serialize_repr, Deserialize_repr};\n");
         preamble.push_str("use typenum;\n");
         let mut import_table: Vec<(String, Vec<String>)> = vec![];


### PR DESCRIPTION
By adding this trait, we can simplify the calling code by not having to call `get_message_name_and_crc` anymore.

It relies on a change to the proc macro as well.