### PR TITLE
add PartialEq derive

### DIFF
--- a/src/bin/api-gen/enums.rs
+++ b/src/bin/api-gen/enums.rs
@@ -181,7 +181,7 @@ impl VppJsApiEnum {
         if self.if_flag() {
             // This tells if the enum is a flag or not
             code.push_str(&format!(
-                "#[derive(Debug,Serialize, Deserialize, Clone, Copy)] \n"
+                "#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)] \n"
             ));
             /* match &self.info.enumtype {
                 Some(len) => code.push_str(&format!("#[repr({})]\n", &len)),


### PR DESCRIPTION
re vpp-api-encoding Issue 4

Add derive for PartialEq so we can use contains method on enums.
